### PR TITLE
Fix crash on fetching shader from shared cache

### DIFF
--- a/framework/Source/OpenGLContext_Shared.swift
+++ b/framework/Source/OpenGLContext_Shared.swift
@@ -20,7 +20,7 @@ public let sharedImageProcessingContext = OpenGLContext()
 extension OpenGLContext {
     public func programForVertexShader(_ vertexShader:String, fragmentShader:String) throws -> ShaderProgram {
         let lookupKeyForShaderProgram = "V: \(vertexShader) - F: \(fragmentShader)"
-        if let shaderFromCache = shaderCache[lookupKeyForShaderProgram] {
+        if let shaderFromCache = sharedImageProcessingContext.runOperationSynchronously({ shaderCache[lookupKeyForShaderProgram] }) {
             return shaderFromCache
         } else {
             return try sharedImageProcessingContext.runOperationSynchronously{


### PR DESCRIPTION
Synchronously fetch vertex shader from `shaderCache`.
Without sync fetch, it might be fetching while `shaderCache` is mutating.